### PR TITLE
sql syntax error rollback patch with test

### DIFF
--- a/lib/DBIx/SchemaChecksum/App/ApplyChanges.pm
+++ b/lib/DBIx/SchemaChecksum/App/ApplyChanges.pm
@@ -106,8 +106,7 @@ sub apply_file {
             } catch {
                 $dbh->rollback;
                 say "SQL error: $_";
-                say "ABORTING!";
-                return;
+                die "ABORTING!";
             };
             say "Successful!" if $self->verbose;
         }

--- a/t/dbs/snippets_rollback/another_change.sql
+++ b/t/dbs/snippets_rollback/another_change.sql
@@ -1,0 +1,9 @@
+-- preSHA1sum: e63a31c18566148984a317006dad897b75d8bdbe
+-- postSHA1sum: b1387d808800a5969f0aa9bcae2d89a0d0b4620b
+
+alter table yat add column foo text;
+
+xalter table yat add column foo2 text;
+
+alter table yat add column foo3 text;
+

--- a/t/dbs/snippets_rollback/first_change.sql
+++ b/t/dbs/snippets_rollback/first_change.sql
@@ -1,0 +1,7 @@
+-- preSHA1sum: 660d1e9b6aec2ac84c2ff6b1acb5fe3450fdd013
+-- postSHA1sum: e63a31c18566148984a317006dad897b75d8bdbe
+
+create table yat (
+	yet_another_column text
+);
+

--- a/t/rollback.t
+++ b/t/rollback.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+use Test::Most;
+use Test::Trap;
+use DBIx::SchemaChecksum::App::ApplyChanges;
+use lib qw(t);
+use MakeTmpDb;
+use DBD::SQLite 1.35;
+
+my $sc = DBIx::SchemaChecksum::App::ApplyChanges->new(
+    dsn => MakeTmpDb->dsn,
+    no_prompt=>1, sqlsnippetdir=> 't/dbs/snippets_rollback');
+
+my $pre_checksum = $sc->checksum;
+is ($pre_checksum,'660d1e9b6aec2ac84c2ff6b1acb5fe3450fdd013','checksum after two changes ok');
+
+trap { $sc->run };
+
+like($trap->stdout,qr/Apply first_change\.sql/,'Output: prompt for first_change.sql');
+like($trap->stdout,qr/Apply another_change\.sql/,'Output: prompt for another_change.sql');
+like($trap->stderr,qr/syntax error/,'another_change.sql syntex error');
+
+my $post_checksum = $sc->checksum;
+is ($post_checksum,'e63a31c18566148984a317006dad897b75d8bdbe','checksum of first change after sql syntax error in second sql');
+
+done_testing();
+


### PR DESCRIPTION
Hi Domm,

return() inside anon sub of catch {} does not terminate the apply_file() sql command execution. After some sql error command, following commands continue to be executed outside of transaction. Fixed by replacing return() with die().

Best regards
Jozef
